### PR TITLE
Updated to run on Python 3.10

### DIFF
--- a/SPOT-RNA.py
+++ b/SPOT-RNA.py
@@ -48,7 +48,7 @@ test_loc = [os.path.join(base_path, 'input_tfr_files', input_file+'.tfrecords')]
 outputs = {}
 mask = {}
 def sigmoid(x):
-    return 1/(1+np.exp(-np.array(x, dtype=np.float128)))
+    return 1/(1+np.exp(-np.array(x, dtype=np.float64)))
 
 for MODEL in range(NUM_MODELS):
 


### PR DESCRIPTION
Changed only the float128 to float64 below. Tested in Python 3.10 and the corresponding numpy, pandas and tensorflow. Also tested working in M1 Mac with tensorflow-macos and tensorflow-metal. All is working as expected.